### PR TITLE
Update ATF.Repository to support NTLM authentication

### DIFF
--- a/ATF.Repository/ATF.Repository.csproj
+++ b/ATF.Repository/ATF.Repository.csproj
@@ -7,20 +7,32 @@
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<TargetFramework>netstandard2.0</TargetFramework>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="creatio.client" Version="1.0.18" />
+
+	<!--Use local creatioclient, when in DEBUG, remove when CreatioCLient version 1.0.24 becomes available on nuget.org-->
+	<Choose>
+		<When Condition="'$(Configuration)' == 'Debug'">
+			<ItemGroup>
+				<ProjectReference Include="..\..\creatioclient\creatioclient\creatioclient.csproj" />
+			</ItemGroup>
+		</When>
+		<Otherwise>
+			<ItemGroup>
+				<PackageReference Include="creatio.client" Version="1.0.24" />
+			</ItemGroup>
+		</Otherwise>
+	</Choose>
+	
+	<ItemGroup Label="Nuget">
 		<PackageReference Include="CreatioSDK" Version="8.1.0.6716" />
 		<PackageReference Include="Common.Logging" Version="3.4.1" />
 		<PackageReference Include="Castle.Core" Version="5.1.1" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.6" />
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
 	</ItemGroup>
+	
 	<ItemGroup>
-	  <Folder Include="Properties" />
-	</ItemGroup>
-	<ItemGroup>
-	  <None Update="logo.png">
-	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-	  </None>
+		<Folder Include="Properties" />
+		<None Update="logo.png">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 </Project>

--- a/ATF.Repository/ATF.Repository.csproj
+++ b/ATF.Repository/ATF.Repository.csproj
@@ -8,21 +8,8 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 	</PropertyGroup>
 
-	<!--Use local creatioclient, when in DEBUG, remove when CreatioCLient version 1.0.24 becomes available on nuget.org-->
-	<Choose>
-		<When Condition="'$(Configuration)' == 'Debug'">
-			<ItemGroup>
-				<ProjectReference Include="..\..\creatioclient\creatioclient\creatioclient.csproj" />
-			</ItemGroup>
-		</When>
-		<Otherwise>
-			<ItemGroup>
-				<PackageReference Include="creatio.client" Version="1.0.24" />
-			</ItemGroup>
-		</Otherwise>
-	</Choose>
-	
 	<ItemGroup Label="Nuget">
+		<PackageReference Include="creatio.client" Version="1.0.24" />
 		<PackageReference Include="CreatioSDK" Version="8.1.0.6716" />
 		<PackageReference Include="Common.Logging" Version="3.4.1" />
 		<PackageReference Include="Castle.Core" Version="5.1.1" />

--- a/ATF.Repository/CreatioClientAdapter.cs
+++ b/ATF.Repository/CreatioClientAdapter.cs
@@ -1,4 +1,6 @@
-﻿namespace ATF.Repository
+﻿using System.Net;
+
+namespace ATF.Repository
 {
 	using Creatio.Client;
 
@@ -12,6 +14,10 @@
 		private CreatioClient _creatioClient;
 		internal CreatioClientAdapter(string applicationUrl, string username, string password, bool isNetCore = false) {
 			_creatioClient = new CreatioClient(applicationUrl, username, password, isNetCore);
+		}
+	
+		internal CreatioClientAdapter(string applicationUrl, ICredentials credentials, bool isNetCore = false) {
+			_creatioClient = new CreatioClient(applicationUrl, true, credentials, isNetCore);
 		}
 
 		internal CreatioClientAdapter(string applicationUrl, string authApp, string clientId, string clientSecret, bool isNetCore = false) {

--- a/ATF.Repository/Providers/RemoteDataProvider.cs
+++ b/ATF.Repository/Providers/RemoteDataProvider.cs
@@ -41,6 +41,18 @@
 			CreatioClientAdapter = new CreatioClientAdapter(applicationUrl, username, password, isNetCore);
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the CreatioClient class with NTLM authentication.
+		/// </summary>
+		/// <param name="applicationUrl">Application Url (e.g.: https://somename.creatio.com)</param>
+		/// <param name="credentials">See <see cref="ICredentials"/></param>
+		/// <param name="isNetCore">Optional parameter, default value <c>false</c></param>
+		public RemoteDataProvider(string applicationUrl, ICredentials credentials, bool isNetCore = false) {
+			_applicationUrl = applicationUrl;
+			_isNetCore = isNetCore;
+			CreatioClientAdapter = new CreatioClientAdapter(applicationUrl, credentials, isNetCore);
+		}
+		
 		public RemoteDataProvider(string applicationUrl, string authApp, string clientId, string clientSecret, bool isNetCore = false) {
 			_applicationUrl = applicationUrl;
 			_isNetCore = isNetCore;

--- a/README.md
+++ b/README.md
@@ -50,19 +50,19 @@ This is an external library and not a part of **Creatio** kernel.
 
 2. Use the following command to install a NuGet package:
 
-```dotnetcli
-dotnet add package ATF.Repository
-```
+	```dotnetcli
+	dotnet add package ATF.Repository
+	```
 
 3. After the command completes, look at the project file to make sure the package was installed.
 
 You can open the `.csproj` file to see the added reference:
 
-```xml
-<ItemGroup>
-  <PackageReference Include="ATF.Repository" Version="2.0.6" />
-</ItemGroup>
-```
+	```xml
+	<ItemGroup>
+	  <PackageReference Include="ATF.Repository" Version="2.0.6" />
+	</ItemGroup>
+	```
 
 ## Install as Creatio-package to the Creatio-solution
 
@@ -91,14 +91,30 @@ We can, depending on our needs, create either a local or a remote data provider.
 ```csharp
 IDataProvider localDataProvider = new LocalDataProvider(UserConnection);
 ```
-#### Creating a remote data provider (*ATF.Repository.RemoteDataProvider*):
+#### Create a remote data provider (`ATF.Repository.RemoteDataProvider`) in one of three ways:
 
-```csharp
-string url = "https://site.url";
-string login = "Login"; // Creatio User Login
-string password = "Password"; // Creatio User Password
-IDataProvider remoteDataProvider = new RemoteDataProvider(url, login, password);
-```
+- For [Cookie-based authentication](https://academy.creatio.com/docs/8.x/dev/development-on-creatio-platform/integrations-and-api/authentication/authentication-basics/overview)
+	```csharp
+	string url = "https://site.url";	// Creatio site URL
+	string login = "Login"; 		// Creatio User Login
+	string password = "Password"; 		// Creatio User Password
+	IDataProvider remoteDataProvider = new RemoteDataProvider(url, login, password);
+	```
+
+- For [OAuth 2.0](https://academy.creatio.com/docs/8.x/dev/development-on-creatio-platform/integrations-and-api/authentication/oauth-2-0-authorization/identity-service-overview)
+	```csharp
+	string url = "https://site.url";		// Creatio site URL
+	string clientId = "clientId"; 			// Creatio User Login
+	string clientSecret = "secter";			// Creatio User Password
+ 	string authApp = "https://site-is.url";	// Creatio IdentityService URL
+	IDataProvider remoteDataProvider = new RemoteDataProvider(url, authApp, clientId, clientSecret);
+	```
+
+- For [NTLM user authentication](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/ntlm-user-authentication)
+	```csharp
+	string url = "https://site.url";	// Creatio site URL
+	IDataProvider provider = new RemoteDataProvider(appUlr, CredentialCache.DefaultNetworkCredentials);
+	```
 
 ### Creating a repository instance:
 For creating repository instance we should use *AppDataContextFactory.GetAppDataContext*.


### PR DESCRIPTION
The commit adds support for **NTLM** user authentication in `ATF.Repository`. 
The changes also include debug-specific local CreatioClient reference, and updates to the README to reflect these added features.